### PR TITLE
Hoisted all local variables out of conditional branches

### DIFF
--- a/kernel_files/tea_leaf_cg_cl.cl
+++ b/kernel_files/tea_leaf_cg_cl.cl
@@ -61,7 +61,7 @@ __kernel void tea_leaf_cg_solve_calc_w
             + (Kx[THARR2D(1, 0, 0)] + Kx[THARR2D(0, 0, 0)]))*p[THARR2D(0, 0, 0)]
             - (Ky[THARR2D(0, 1, 0)]*p[THARR2D(0, 1, 0)] + Ky[THARR2D(0, 0, 0)]*p[THARR2D(0, -1, 0)])
             - (Kx[THARR2D(1, 0, 0)]*p[THARR2D(1, 0, 0)] + Kx[THARR2D(0, 0, 0)]*p[THARR2D(-1, 0, 0)]);
-        
+
         pw_shared[lid] = p[THARR2D(0, 0, 0)]*w[THARR2D(0, 0, 0)];
     }
 
@@ -96,10 +96,10 @@ __kernel void tea_leaf_cg_solve_calc_ur
         u[THARR2D(0, 0, 0)] += alpha*p[THARR2D(0, 0, 0)];
         r[THARR2D(0, 0, 0)] -= alpha*w[THARR2D(0, 0, 0)];
     }
-
+    __local double z_l[BLOCK_SZ];
     if (PRECONDITIONER == TL_PREC_JAC_BLOCK)
     {
-        __local double z_l[BLOCK_SZ];
+
 
         if (WITHIN_BOUNDS)
         {
@@ -158,4 +158,3 @@ __kernel void tea_leaf_cg_solve_calc_p
         }
     }
 }
-

--- a/kernel_files/tea_leaf_cheby_cl.cl
+++ b/kernel_files/tea_leaf_cheby_cl.cl
@@ -26,12 +26,10 @@ __kernel void tea_leaf_cheby_solve_init_p
 
         r[THARR2D(0, 0, 0)] = u0[THARR2D(0, 0, 0)] - w[THARR2D(0, 0, 0)];
     }
-
+    __local double r_l[BLOCK_SZ];
+    __local double z_l[BLOCK_SZ];
     if (PRECONDITIONER == TL_PREC_JAC_BLOCK)
     {
-        __local double r_l[BLOCK_SZ];
-        __local double z_l[BLOCK_SZ];
-
         r_l[lid] = 0;
         z_l[lid] = 0;
 
@@ -105,10 +103,10 @@ __kernel void tea_leaf_cheby_solve_calc_p
         r[THARR2D(0, 0, 0)] = u0[THARR2D(0, 0, 0)] - w[THARR2D(0, 0, 0)];
     }
 
+    __local double r_l[BLOCK_SZ];
+    __local double z_l[BLOCK_SZ];
     if (PRECONDITIONER == TL_PREC_JAC_BLOCK)
     {
-        __local double r_l[BLOCK_SZ];
-        __local double z_l[BLOCK_SZ];
 
         r_l[lid] = 0;
         z_l[lid] = 0;
@@ -145,4 +143,3 @@ __kernel void tea_leaf_cheby_solve_calc_p
         }
     }
 }
-

--- a/kernel_files/tea_leaf_ppcg_cl.cl
+++ b/kernel_files/tea_leaf_ppcg_cl.cl
@@ -19,10 +19,11 @@ __kernel void tea_leaf_ppcg_solve_init_sd
 {
     __kernel_indexes;
 
+    __local double r_l[BLOCK_SZ];
+    __local double z_l[BLOCK_SZ];
+
     if (PRECONDITIONER == TL_PREC_JAC_BLOCK)
     {
-        __local double r_l[BLOCK_SZ];
-        __local double z_l[BLOCK_SZ];
 
         r_l[lid] = 0;
         z_l[lid] = 0;
@@ -108,10 +109,10 @@ __kernel void tea_leaf_ppcg_solve_calc_sd
         row <= (y_max + HALO_DEPTH - 1) + bounds_extra_y &&
         column <= (x_max + HALO_DEPTH - 1) + bounds_extra_x;
 
+    __local double r_l[BLOCK_SZ];
+    __local double z_l[BLOCK_SZ];
     if (PRECONDITIONER == TL_PREC_JAC_BLOCK)
     {
-        __local double r_l[BLOCK_SZ];
-        __local double z_l[BLOCK_SZ];
 
         r_l[lid] = 0;
         z_l[lid] = 0;
@@ -152,4 +153,3 @@ __kernel void tea_leaf_ppcg_solve_calc_sd
         }
     }
 }
-


### PR DESCRIPTION
I have hoisted all local variables out of conditional branches. This fixes the bug that can occur as the standard states "variables in the local address space can only be declared in the outermost scope of a kernel function".